### PR TITLE
[Profiling] Add Profiling Support for Performance Analysis

### DIFF
--- a/master/agents/planner.py
+++ b/master/agents/planner.py
@@ -1,5 +1,4 @@
-import json
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Union
 
 import yaml
 from agents.prompts import MASTER_PLANNING_PLANNING
@@ -21,6 +20,8 @@ class GlobalTaskPlanner:
         self.global_model, self.model_name = self._gat_model_info_from_config(
             config["model"]
         )
+
+        self.profiling = config["profiling"]
 
     def _gat_model_info_from_config(self, config: Dict) -> tuple:
         """Get the model info from config."""
@@ -51,6 +52,18 @@ class GlobalTaskPlanner:
             config = yaml.safe_load(f)
         return config
 
+    def display_profiling_info(self, description: str, message: any):
+        """
+        Outputs profiling information if profiling is enabled.
+
+        :param message: The content to be printed. Can be of any type.
+        :param description: A brief title or description for the message.
+        """
+        if self.profiling:
+            module_name = "master"  # Name of the current module
+            print(f" [{module_name}] {description}:")
+            print(message)
+
     def forward(self, task: str) -> str:
         """Get the sub-tasks from the task."""
 
@@ -70,6 +83,11 @@ class GlobalTaskPlanner:
             },
         ]
 
+        self.display_profiling_info("messages", messages)
+
+        from datetime import datetime
+
+        start_inference = datetime.now()
         response = self.global_model.chat.completions.create(
             model=self.model_name,
             messages=messages,
@@ -78,4 +96,13 @@ class GlobalTaskPlanner:
             max_tokens=2048,
             seed=42,
         )
+        end_inference = datetime.now()
+
+        self.display_profiling_info(
+            "inference time",
+            f"inference start:{start_inference} end:{end_inference} during:{end_inference-start_inference}",
+        )
+        self.display_profiling_info("response", response)
+        self.display_profiling_info("response.usage", response.usage)
+
         return response.choices[0].message.content

--- a/master/config.yaml
+++ b/master/config.yaml
@@ -33,16 +33,16 @@ model:
   # Number of retries for planning
   MODEL_RETRY_PLANNING: 5
   MODEL_DICT:
-      # Model name for the cloud server
-      CLOUD_MODEL: "/workspace/model/BAAI/RoboBrain2.0-7B"
-      # Deploy for the cloud server
-      CLOUD_TYPE: "default"
-      # API key for the cloud server
-      CLOUD_API_KEY: "EMPTY"
-      # URL of the cloud server
-      CLOUD_SERVER: "http://localhost:4567/v1/"
-      # Maximum number of chat messages to keep in memory
-      MAX_CHAT_MESSAGE: 50
+    # Model name for the cloud server
+    CLOUD_MODEL: "/workspace/model/BAAI/RoboBrain2.0-7B"
+    # Deploy for the cloud server
+    CLOUD_TYPE: "default"
+    # API key for the cloud server
+    CLOUD_API_KEY: "EMPTY"
+    # URL of the cloud server
+    CLOUD_SERVER: "http://localhost:4567/v1/"
+    # Maximum number of chat messages to keep in memory
+    MAX_CHAT_MESSAGE: 50
 
 
 # Collaborator Parameters
@@ -69,3 +69,6 @@ logger:
   MASTER_LOGGER_FILE: ".logs/master_agent.log"
   # Path to save the robot memory file
   ROBOT_MEMORY_YAML: ".log/robot_memory.yaml"
+
+# Output reasoning context, time cost and other information
+profiling: true

--- a/slaver/config.yaml
+++ b/slaver/config.yaml
@@ -43,3 +43,6 @@ camera:
 robot:
   # Path to the robot fold
   PATH: "demo_robot"
+
+# Output reasoning context, time cost and other information
+profiling: true

--- a/slaver/run.py
+++ b/slaver/run.py
@@ -14,9 +14,13 @@ from typing import Dict, List, Optional
 import yaml
 from agents.models import AzureOpenAIServerModel, OpenAIServerModel
 from agents.slaver_agent import ToolCallingAgent
+from flag_scale.flagscale.agent.Collaboration import Collaborator
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
-from tools.utils import collaborator, config
+from tools.utils import Config
+
+config = Config.load_config()
+collaborator = Collaborator.from_config(config=config["collaborator"])
 
 
 class RobotManager:
@@ -61,6 +65,8 @@ class RobotManager:
                     azure_deployment=candidate["AZURE_DEPLOYMENT"],
                     api_key=candidate["AZURE_API_KEY"],
                     api_version=candidate["AZURE_API_VERSION"],
+                    support_tool_calls=config["tool"]["SUPPORT_TOOL_CALLS"],
+                    profiling=config["profiling"],
                 )
                 model_name = config["model"]["MODEL_SELECT"]
             elif candidate["CLOUD_TYPE"] == "default":
@@ -68,6 +74,8 @@ class RobotManager:
                     api_key=candidate["CLOUD_API_KEY"],
                     api_base=candidate["CLOUD_SERVER"],
                     model_id=candidate["CLOUD_MODEL"],
+                    support_tool_calls=config["tool"]["SUPPORT_TOOL_CALLS"],
+                    profiling=config["profiling"],
                 )
                 model_name = config["model"]["MODEL_SELECT"]
             else:

--- a/slaver/tools/utils.py
+++ b/slaver/tools/utils.py
@@ -156,8 +156,3 @@ class Config:
         with open(config_path, "r", encoding="utf-8") as f:
             config = yaml.safe_load(f)
         return config
-
-
-config = Config.load_config()
-
-collaborator = Collaborator.from_config(config=config["collaborator"])


### PR DESCRIPTION
### ✅ Key Changes for Profiling:

- **Added `display_profiling_info` utility method** in both `GlobalTaskPlanner` (master) and `Model` (slaver) classes to conditionally log performance-related data when profiling is enabled.
- **Logged metrics include**:
  - Inference start & end time
  - Total inference duration
  - Input messages sent to the model
  - Full response from the model
  - Token usage information (`prompt_tokens`, `completion_tokens`)
- **Configurable via `config.yaml`** using the new `profiling: true/false` flag.

### 🛠️ Example Configuration (`config.yaml`):

```yaml
# Enable or disable profiling globally
profiling: true
```