### PR TITLE
fix: update import for Collaborator and pin compatible package versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ exceptiongroup==1.2.2
 fastapi==0.115.12
 ffmpy==0.5.0
 filelock==3.18.0
-flag_scale @ git+https://github.com/FlagOpen/FlagScale@35c2739
 Flask==3.1.0
 fsspec==2025.3.2
 gradio==5.25.2
@@ -28,6 +27,7 @@ jiter==0.9.0
 markdown-it-py==3.0.0
 MarkupSafe==3.0.2
 mdurl==0.1.2
+mcp==1.10.1
 numpy==2.2.5
 openai==1.75.0
 orjson==3.10.16

--- a/slaver/run.py
+++ b/slaver/run.py
@@ -14,7 +14,8 @@ from typing import Dict, List, Optional
 import yaml
 from agents.models import AzureOpenAIServerModel, OpenAIServerModel
 from agents.slaver_agent import ToolCallingAgent
-from flag_scale.flagscale.agent.Collaboration import Collaborator
+from flag_scale.flagscale.agent.collaboration import Collaborator
+
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 from tools.utils import Config


### PR DESCRIPTION
- Fixed import path case issue for `Collaborator` to ensure cross-platform compatibility.
- Replaced editable Git dependency with pinned `mcp==1.10.1` for stable installation.