### PR TITLE
refactor: switch from stdio to HTTP MCP client and update robot status APIStand alone

### DIFF
--- a/master/run.py
+++ b/master/run.py
@@ -1,8 +1,9 @@
 import traceback
 
+import json
 import psutil
 from agents.agent import GlobalAgent
-from flask import Flask, jsonify, render_template, request, send_from_directory
+from flask import Flask, jsonify, request
 from flask_cors import CORS
 from flask_socketio import SocketIO
 
@@ -48,12 +49,13 @@ def robot_status():
         JSON response with robot status
     """
     try:
-        registered_robots = master_agent.collaborator.retrieve_all_agents_name()
-        registered_robots_status = {}
-        for registered_robot in registered_robots:
-            registered_robots_status[registered_robot.get("robot_name")] = (
-                registered_robot.get("robot_state")
-            )
+        registered_robots = master_agent.collaborator.retrieve_all_agents()
+        registered_robots_status = []
+        for robot_name, robot_info in registered_robots.items():
+            registered_robots_status.append({
+                "robot_name": robot_name,
+                "robot_state": json.loads(robot_info).get("robot_state")
+            })
         return jsonify(registered_robots_status), 200
     except Exception as e:
         return jsonify({"error": "Internal server error", "details": str(e)}), 500

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ exceptiongroup==1.2.2
 fastapi==0.115.12
 ffmpy==0.5.0
 filelock==3.18.0
-flag_scale @ git+https://github.com/FlagOpen/FlagScale@35c2739
 Flask==3.1.0
 fsspec==2025.3.2
 gradio==5.25.2
@@ -28,6 +27,7 @@ jiter==0.9.0
 markdown-it-py==3.0.0
 MarkupSafe==3.0.2
 mdurl==0.1.2
+mcp==1.10.1
 numpy==2.2.5
 openai==1.75.0
 orjson==3.10.16

--- a/slaver/config.yaml
+++ b/slaver/config.yaml
@@ -44,5 +44,9 @@ robot:
   # Path to the robot fold
   PATH: "demo_robot"
 
+# mcp
+mcp:
+  URL: "http://127.0.0.1:8888"
+
 # Output reasoning context, time cost and other information
 profiling: true

--- a/slaver/run.py
+++ b/slaver/run.py
@@ -14,7 +14,8 @@ from typing import Dict, List, Optional
 import yaml
 from agents.models import AzureOpenAIServerModel, OpenAIServerModel
 from agents.slaver_agent import ToolCallingAgent
-from flag_scale.flagscale.agent.Collaboration import Collaborator
+from flag_scale.flagscale.agent.collaboration import Collaborator
+
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 from tools.utils import Config

--- a/slaver/run.py
+++ b/slaver/run.py
@@ -16,8 +16,9 @@ from agents.models import AzureOpenAIServerModel, OpenAIServerModel
 from agents.slaver_agent import ToolCallingAgent
 from flag_scale.flagscale.agent.collaboration import Collaborator
 
-from mcp import ClientSession, StdioServerParameters
-from mcp.client.stdio import stdio_client
+from mcp.client.streamable_http import streamablehttp_client
+from mcp import ClientSession
+
 from tools.utils import Config
 
 config = Config.load_config()
@@ -160,14 +161,10 @@ class RobotManager:
     async def connect_to_robot(self):
         """Connect to an MCP server"""
 
-        server_params = StdioServerParameters(
-            command="python", args=[config["robot"]["PATH"] + "/skill.py"], env=None
-        )
-
         stdio_transport = await self.exit_stack.enter_async_context(
-            stdio_client(server_params)
+            streamablehttp_client(f'{config["mcp"]["URL"]}/mcp')
         )
-        self.stdio, self.write = stdio_transport
+        self.stdio, self.write, _ = stdio_transport
         self.session = await self.exit_stack.enter_async_context(
             ClientSession(self.stdio, self.write)
         )


### PR DESCRIPTION
- Replaced stdio-based MCP connection with HTTP-based streamable client using config-defined URL.
- Updated `config.yaml` to include MCP server URL under `mcp.URL`.
- Refactored `robot_status` endpoint to return structured list of registered robot states.
- Removed unused Flask imports and simplified code structure.